### PR TITLE
Limit dependency versions of gdal and spatialite to avoid some issues

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 112d98ce5265cacd50c9b8740843e80a7a42302043200a122cac073d8dde83d7
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -21,9 +21,9 @@ requirements:
   run:
     - cloudpickle
     - fiona
-    - gdal
+    - gdal <3.7.2
     - geopandas >=0.11,<0.14
-    - libspatialite >=5.0
+    - libspatialite >=5.0,<5.1
     - numpy
     - pandas
     - psutil


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Verify if the release channel is correctly set to main, geofileops_rc or geofileops_dev (depending on stable, rc or dev version), especially after rerender changed files!
* [x] If rerender changed files, verify if .github/PULL_REQUEST_TEMPLATE.md is still present. If not, copy it again from the backup directory.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->